### PR TITLE
“ernie-1.0-zh-chnsenticorp-tutorials.ipynb”中创建GradShapNLPInterpreter对象的参数有误

### DIFF
--- a/tutorials/ernie-1.0-zh-chnsenticorp-tutorials.ipynb
+++ b/tutorials/ernie-1.0-zh-chnsenticorp-tutorials.ipynb
@@ -373,7 +373,7 @@
     }
    ],
    "source": [
-    "ig = it.GradShapNLPInterpreter(model, True)\n",
+    "ig = it.GradShapNLPInterpreter(model, 'gpu', True)\n",
     "\n",
     "pred_labels, pred_probs, avg_gradients = ig.interpret(\n",
     "    preprocess_fn(data),\n",


### PR DESCRIPTION
直接运行代码段“GradShapNLPInterpreter”，出现下述错误：
![image](https://user-images.githubusercontent.com/89008682/157160234-6c19911a-eac9-44ff-93eb-40ded030ef0e.png)
其原因是下述语句参数有误：
ig = it.GradShapNLPInterpreter(model, True)
第2个参数是设备类型，可以选择'gpu'或'cpu'，而不是布尔型True。
因此、将上述语句的参数修改为(model, 'gpu', True)。
